### PR TITLE
Introduce threshold for roll leader detection

### DIFF
--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -2608,6 +2608,17 @@ void RollImage::analyzeLeaders(void) {
 	// std::cerr << "botLeftAvg = "  << botLeftAvg << std::endl;
 	// std::cerr << "botRightAvg = " << botRightAvg << std::endl;
 
+	// as long as the left and right margins remain within a small
+	// threshold (5 pixels), assume that no roll leader is present.
+	double threshold = 5.0;
+	if ((fabs(topLeftAvg - botLeftAvg) < threshold) &&
+			(fabs(topRightAvg - botRightAvg) < threshold)) {
+		setLeaderIndex(0);
+		setPreleaderIndex(0);
+		m_analyzedLeaders = true;
+		return;
+	}
+
 	if ((topLeftAvg > botLeftAvg) && (topRightAvg < botRightAvg)) {
 		// do nothing, everything is as expected
 	} else if ((topLeftAvg < botLeftAvg) && (topRightAvg > botRightAvg)) {


### PR DESCRIPTION
I have recently received some roll scans from Marc Widuch. With some adjustments they can be processed by the roll-image-parser. However, all of the scans start right after the roll leader, which made `analyzeLeaders()` fail and exit early. The straight-forward solution is to introduce a threshold, which, when not exceeded, will make the program assume that no roll leader is present on the scan.